### PR TITLE
Remove dependency on gow

### DIFF
--- a/ssh-copy-id/ssh-copy-id.ps1
+++ b/ssh-copy-id/ssh-copy-id.ps1
@@ -16,7 +16,6 @@
     COMMENT: Modified to work with Scoop.sh
     DEPENDENCIES: 
         ssh
-        gow
  .HELPURL
     http://stackoverflow.com
  .SEEALSO
@@ -93,7 +92,7 @@ trap { #Stop on all errors
     Write-Error "ERROR: $_"
 }
 
-$PlinkAndPath = $(which ssh)
+$PlinkAndPath = $((Get-Command -Name ssh).Source)
  
 #from http://serverfault.com/questions/224810/is-there-an-equivalent-to-ssh-copy-id-for-windows
 $Commands = @()


### PR DESCRIPTION
Replace use of 'which' to locate ssh binary with PS native 'Get-Command' to allow removal of dependency on gow.